### PR TITLE
Fix hr renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ const defaultNodeRenderers = {
     [BLOCKS.QUOTE]: (node, key, h, next) => (
         h('blockquote', { key }, next(node.content, key, h, next))
     ),
-    [BLOCKS.HR]: (_node, key, _h) => h('hr', { key }, {}),
+    [BLOCKS.HR]: (_node, key, h) => h('hr', { key }, {}),
     [INLINES.ASSET_HYPERLINK]: (node, key, h) =>
         defaultInline(INLINES.ASSET_HYPERLINK, node, key, h),
     [INLINES.ENTRY_HYPERLINK]: (node, key, h) =>


### PR DESCRIPTION
It looks like just a typo, the HR function was using a different name for the passed in function than the other renderers.

```stacktrace
vue.runtime.esm.js?2b0e:1832 ReferenceError: h is not defined
    at Object.hr (index.js?1b1a:63)
    at renderNode (index.js?1b1a:112)
    at nodes.map (index.js?1b1a:92)
    at Array.map (<anonymous>)
    at renderNodeList (index.js?1b1a:92)
    at render (index.js?1b1a:134)
    at createFunctionalComponent (vue.runtime.esm.js?2b0e:4179)
    at createComponent (vue.runtime.esm.js?2b0e:4352)
    at _createElement (vue.runtime.esm.js?2b0e:4537)
    at createElement (vue.runtime.esm.js?2b0e:4474)
```