### PR TITLE
Add server side rendering notes to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,22 @@ The `markRenderers` prop should be one of the following `MARKS` properties as de
 - `ITALIC`
 - `UNDERLINE`
 - `CODE`
+
+## Server Side Rendering
+Since this package is using the ESM module syntax, you most likely need to tranpile the package into CommonJS.
+
+### [Nuxt](https://nuxtjs.org/)
+
+You can configure Nuxt to transpile packages from your node_modules in the `nuxt.config.js` by adding it to `build.transpile` like this:
+
+```js
+// nuxt.config.js
+
+module.exports = {
+  // ...
+  build: {
+    transpile: ['contentful-rich-text-vue-renderer'],
+    // ...
+  }
+}
+```


### PR DESCRIPTION
I have tried to use this package for SSR with Nuxt and always got an error of `Unexpected token {` while rendering the page. It took me a while to figure out, that the reason for this was that the import statement of this module.

Node could not deal with the ESM syntax used in this package. When transpiling it to use the CommonJS syntax, everything went smoothly.

To help others that may run into the same problem, I thought adding a chapter to readme would be nice.