### PR TITLE
fixes hyperlinks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,9 @@ const defaultNodeRenderers = {
             'a',
             {
                 key,
-                href: node.data.uri
+                attrs: {
+                  href: node.data.uri
+                }
             },
             next(node.content, key, h, next)
         )


### PR DESCRIPTION
Hyperlinks are created as anchor elements but don't contain any reference. This commit fixes that.