### PR TITLE
Add repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "contentful-rich-text-vue-renderer",
   "version": "2.0.0",
   "description": "Render Contentful Rich Text field using Vue components",
+  "homepage": "https://github.com/paramander/contentful-rich-text-vue-renderer#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paramander/contentful-rich-text-vue-renderer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/paramander/contentful-rich-text-vue-renderer/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Add repository links in `package.json` to allow linking from npmjs.org, for example:

![Screen Shot 2021-02-25 at 00 23 37](https://user-images.githubusercontent.com/1385160/109124523-deb3de80-76ff-11eb-8bdb-1cd02e134106.png)
