### PR TITLE
Avoid render loops in node-renderers test

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -419,9 +419,9 @@ describe("RichText", () => {
             return childNode;
           });
 
-          node.content = [].concat.apply([], nodeContentWithNewlineBr);
+          const content = [].concat.apply([], nodeContentWithNewlineBr);
 
-          return h('p', { key }, next(node.content, key, h, next));
+          return h('p', { key }, next(content, key, h, next));
         }
       };
 


### PR DESCRIPTION
### What Does This Do?

Fixes #33 by not mutating `node.content` during text node rendering.

Many thanks to @tolgap [for providing this solution](https://github.com/paramander/contentful-rich-text-vue-renderer/issues/33#issuecomment-882614228)!

### Demonstration

#### Before

Vue warns about an infinite update loop:

([Code Sandbox](https://codesandbox.io/s/vigilant-satoshi-w4hhc?file=/src/App.vue))

<img width="600" alt="Vue warns, 'You may have an infinite update loop in a component render function.'" src="https://user-images.githubusercontent.com/5732000/125147839-eba7fc00-e0fb-11eb-8856-fda8efe26b4f.png">

#### After

No warning about infinite update loops:

([Code Sandbox](https://codesandbox.io/s/dreamy-bassi-0whgo?file=/src/App.vue))

<img width="600" alt="No warnings about infinite update loops" src="https://user-images.githubusercontent.com/5732000/126201568-0ca45e13-f15d-4445-aa29-b702b2d2d2a0.png">
