### PR TITLE
feat: support strikethrough mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ The `nodeRenderers` prop should be one of the following `BLOCKS` and `INLINES` p
   - `EMBEDDED_ENTRY`
   - `EMBEDDED_ASSET`
   - `TABLE`
+  - `TABLE_ROW`
+  - `TABLE_CELL`
+  - `TABLE_HEADER_CELL`
 
 - `INLINES`
   - `EMBEDDED_ENTRY` (this is different from the `BLOCKS.EMBEDDED_ENTRY`)
@@ -238,3 +241,4 @@ The `markRenderers` prop should be one of the following `MARKS` properties as de
 - `CODE`
 - `SUBSCRIPT`
 - `SUPERSCRIPT`
+- `STRIKETHROUGH`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.12.10",
         "@babel/preset-env": "^7.12.11",
-        "@contentful/rich-text-types": "^15.14.1",
+        "@contentful/rich-text-types": "^17.0.1",
         "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.0",
@@ -23,7 +23,7 @@
         "vue": "^3.2.37"
       },
       "peerDependencies": {
-        "@contentful/rich-text-types": "^15.14.1"
+        "@contentful/rich-text-types": ">=16.5.0"
       },
       "peerDependenciesMeta": {
         "@contentful/rich-text-types": {
@@ -1773,10 +1773,14 @@
       }
     },
     "node_modules/@contentful/rich-text-types": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.15.1.tgz",
-      "integrity": "sha512-oheW0vkxWDuKBIIXDeJfZaRYo+NzKbC4gETMhH+MGJd4nfL9cqrOvtRxZBgnhICN4vDpH4my/zUIZGKcFqGSjQ==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.1.tgz",
+      "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5074,6 +5078,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -10881,10 +10898,13 @@
       }
     },
     "@contentful/rich-text-types": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.15.1.tgz",
-      "integrity": "sha512-oheW0vkxWDuKBIIXDeJfZaRYo+NzKbC4gETMhH+MGJd4nfL9cqrOvtRxZBgnhICN4vDpH4my/zUIZGKcFqGSjQ==",
-      "dev": true
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.1.tgz",
+      "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^3.0.0"
+      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -13487,6 +13507,12 @@
           }
         }
       }
+    },
+    "is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "vue": "^3.2.37"
       },
       "peerDependencies": {
-        "@contentful/rich-text-types": ">=16.5.0"
+        "@contentful/rich-text-types": "^16.5.0 || ^17.0.0"
       },
       "peerDependenciesMeta": {
         "@contentful/rich-text-types": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vue"
   ],
   "peerDependencies": {
-    "@contentful/rich-text-types": "^15.14.1"
+    "@contentful/rich-text-types": ">=16.5.0"
   },
   "peerDependenciesMeta": {
     "@contentful/rich-text-types": {
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
-    "@contentful/rich-text-types": "^15.14.1",
+    "@contentful/rich-text-types": "^17.0.1",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vue"
   ],
   "peerDependencies": {
-    "@contentful/rich-text-types": ">=16.5.0"
+    "@contentful/rich-text-types": "^16.5.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "@contentful/rich-text-types": {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const defaultMarkRenderers = {
   [MARKS.CODE]: (children, key) => h("code", { key }, children),
   [MARKS.SUPERSCRIPT]: (children, key) => h("sup", { key }, children),
   [MARKS.SUBSCRIPT]: (children, key) => h("sub", { key }, children),
+  [MARKS.STRIKETHROUGH]: (children, key) => h("s", { key }, children),
 };
 
 const defaultNodeRenderers = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -49,6 +49,11 @@ describe("RichText", () => {
               value: "Subpar",
               marks: [{ type: MARKS.SUBSCRIPT }],
             },
+            {
+              nodeType: "text",
+              value: "Irrelevant",
+              marks: [{ type: MARKS.STRIKETHROUGH }],
+            },
           ],
         },
       ]);
@@ -56,7 +61,7 @@ describe("RichText", () => {
 
       it("renders them all in a single paragraph", () => {
         expect(rendered.html()).toBe(
-          '<p><strong>Hello</strong><em> world!</em><code>console.log("yo");</code><u>Greetings!</u><sup>Superb!</sup><sub>Subpar</sub></p>'
+          '<p><strong>Hello</strong><em> world!</em><code>console.log("yo");</code><u>Greetings!</u><sup>Superb!</sup><sub>Subpar</sub><s>Irrelevant</s></p>'
         );
       });
     });
@@ -83,11 +88,23 @@ describe("RichText", () => {
             { type: MARKS.SUBSCRIPT },
           ],
         },
+        {
+          nodeType: "text",
+          value: "!",
+          marks: [
+            { type: MARKS.UNDERLINE },
+            { type: MARKS.ITALIC },
+            { type: MARKS.BOLD },
+            { type: MARKS.STRIKETHROUGH },
+          ],
+        },
       ]);
       const rendered = mount(RichText, { props: { document } });
 
       it("renders all overlapping marks in order", () => {
-        expect(rendered.html()).toBe("<strong><em><u><sup>Hello</sup></u></em></strong>\n<strong><em><u><sub>World</sub></u></em></strong>");
+        expect(rendered.html()).toBe(
+          "<strong><em><u><sup>Hello</sup></u></em></strong>\n<strong><em><u><sub>World</sub></u></em></strong>\n<u><em><strong><s>!</s></strong></em></u>"
+        );
       });
     });
   });


### PR DESCRIPTION
Add support for the strikethrough mark. Currently, if a strikethrough is used in Contentful it will break the render. This is a similar change to #53.

Strikethrough support was added in `@contentful/rich-text-types@16.5.0`: <https://github.com/contentful/rich-text/releases/tag/%40contentful%2Frich-text-types%4016.5.0>

This should also resolve #58, by bumping the peer dependency.
