### PR TITLE
Fix extraneous non-props attributes warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,7 @@ const RichText = ({ nodeRenderers, markRenderers, document }) => {
   return renderNodeList(document.content, "RichText-", renderer);
 };
 
+RichText.inheritAttrs = false;
 RichText.props = ["document", "nodeRenderers", "markRenderers"];
 
 export default RichText;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -757,4 +757,33 @@ describe("RichText", () => {
       });
     });
   });
+
+  describe("options", () => {
+    let consoleWarnMock;
+
+    beforeEach(() => {
+      consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleWarnMock.mockRestore();
+    });
+
+    it("does not emit extraneous non-props warning", () => {
+      mount(RichText, {
+        props: {
+          document: withDocument([]),
+        },
+        attrs: {
+          "data-v-3b868348": "",
+        },
+      });
+
+      expect(
+        consoleWarnMock.mock.calls.find(call => call.find(
+          message => message === "[Vue warn]: Extraneous non-props attributes (data-v-3b868348) were passed to component but could not be automatically inherited because component renders fragment or text root nodes.",
+        )),
+      ).toBe(undefined);
+    });
+  });
 });


### PR DESCRIPTION
This PR disables attribute inheritance as the component has multiple root elements and is causing the Vue warning `[Vue warn]: Extraneous non-props attributes (data-v-3b868348) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes. 
  at <RichText document= { ...` when parent components use scoped styles.